### PR TITLE
Typo fix in get_del_q.py

### DIFF
--- a/script/get_del_Q.py
+++ b/script/get_del_Q.py
@@ -65,8 +65,7 @@ if __name__ == '__main__':
     '''
     '''
     parser = argparse.ArgumentParser(formatter_class=argparse.RawTextHelpFormatter,
-                                     description="This script calculates the atomic mass weigted distance 
-                                                  between two structures.)
+                                     description="This script calculates the atomic mass weighted distance between two structures.")
     parser.add_argument("-i","--init",
                         help="initial input file (POSCAR format) ",default="./POSCAR_i")
     parser.add_argument("-f","--fin",


### PR DESCRIPTION
There was a typo in the argparse section, a missing double quote, which made this script not run under Python3.

I am not sure whether I should merge to `master` or `develop` :)